### PR TITLE
More precision about LDAP_ENCRYPTION

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ background
 
 LDAP_Background_Sync_Interval: At which interval does the background task sync
 
-LDAP_Encryption: If using LDAPS
+LDAP_Encryption: If using LDAPS, set it to 'ssl', else it will use 'ldap://'
 
 LDAP_CA_Cert: The certification for the LDAPS server
 


### PR DESCRIPTION
If you want to connect with ldaps to your ldap server, setting
LDAP_ENCRYPTION to true, will not work because of the if statement only
checking if LDAP_ENCRYPTION is set to 'ssl'.

Follow up of [#1980](https://github.com/wekan/wekan/pull/1980)