### PR TITLE
Add LDAP email matching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ LDAP_Username_Field: Which field contains the ldap username
 
 LDAP_Fullname_Field: Which field contains the ldap full name
 
+LDAP_Email_Match_Enable: Allow existing account matching by e-mail address when username does not match
+
+LDAP_Email_Match_Require: Require existing account matching by e-mail address when username does match
+
+LDAP_Email_Match_Verified: Require existing account email address to be verified for matching
+
+LDAP_Email_Field: Which field contains the LDAP e-mail address
+
 LDAP_Sync_User_Data:
 
 LDAP_Sync_User_Data_FieldMap:
@@ -109,6 +117,11 @@ LDAP_Default_Domain: The default domain of the ldap it is used to create email i
   "LDAP_User_Search_Scope": "",
   "LDAP_Unique_Identifier_Field": "guid",
   "LDAP_Username_Field": "uid",
+  "LDAP_Fullname_Field": "cn",
+  "LDAP_Email_Match_Enable": true,
+  "LDAP_Email_Match_Require": false,
+  "LDAP_Email_Match_Verified": false,
+  "LDAP_Email_Field": "mail",
   "LDAP_Sync_User_Data": false,
   "LDAP_Sync_User_Data_FieldMap": "{\"cn\":\"name\", \"mail\":\"email\"}",
   "LDAP_Merge_Existing_Users": true,

--- a/server/sync.js
+++ b/server/sync.js
@@ -71,6 +71,18 @@ export function getLdapUsername(ldapUser) {
   return ldapUser.getLDAPValue(usernameField);
 }
 
+export function getLdapEmail(ldapUser) {
+  const emailField = LDAP.settings_get('LDAP_EMAIL_FIELD');
+
+  if (emailField.indexOf('#{') > -1) {
+    return emailField.replace(/#{(.+?)}/g, function(match, field) {
+      return ldapUser.getLDAPValue(field);
+    });
+  }
+
+  return ldapUser.getLDAPValue(emailField);
+}
+
 export function getLdapFullname(ldapUser) {
   const fullnameField = LDAP.settings_get('LDAP_FULLNAME_FIELD');
   if (fullnameField.indexOf('#{') > -1) {


### PR DESCRIPTION
#### Problem
Currently, there's no way to match LDAP accounts and Wekan accounts with anything but an exact username match. In our case, users have already created accounts with usernames that don't match their LDAP username. Therefore, no existing user account is detected for merging and the task of changing each user's Wekan username to match their LDAP username will be arduous. However, in most cases the e-mail address of the Wekan user matches their LDAP e-mail address.

#### Solution
This introduces four new environment variables to allow LDAP accounts to be matched with existing Wekan accounts using e-mail addresses as well as usernames when LDAP_Email_Match_Enable is true.

When a regular username match is detected, the merge can be additionally verified using the e-mail address if LDAP_Email_Match_Require is true. This stops erroneous matching (as in our case, where some users have set usernames that match another users' LDAP username). This is a reliable solution to issue #36 

You must specify an LDAP email address field with LDAP_Email_Field. You can also limit email matching to just verified email addresses in Wekan if LDAP_Email_Match_Verified is true.

Supported with wekan/wekan#2198