### PR TITLE
Add support for admin status sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Accounts_CustomFields:
 
 LDAP_Default_Domain: The default domain of the ldap it is used to create email if the field is not map correctly with the LDAP_Sync_User_Data_FieldMap
 
+LDAP_SYNC_ADMIN_STATUS: enable/disable syncing of admin status based on ldap groups
+
+LDAP_SYNC_ADMIN_GROUPS: comma separated list of admin group names.
+
 
 
 
@@ -125,6 +129,8 @@ LDAP_Default_Domain: The default domain of the ldap it is used to create email i
   "LDAP_Sync_User_Data": false,
   "LDAP_Sync_User_Data_FieldMap": "{\"cn\":\"name\", \"mail\":\"email\"}",
   "LDAP_Merge_Existing_Users": true,
-  "UTF8_Names_Slugify": true
+  "UTF8_Names_Slugify": true,
+  "LDAP_SYNC_ADMIN_STATUS": true,
+  "LDAP_SYNC_ADMIN_GROUP": "group1,group2"
 }
 ```

--- a/server/loginHandler.js
+++ b/server/loginHandler.js
@@ -176,7 +176,7 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
 
       if (groups.length > 0) {
         user.isAdmin = true;
-        Meteor.users.update({_id: user.userId()}, {$set: {isAdmin: true}});
+        Meteor.users.update({_id: user.userId}, {$set: {isAdmin: true}});
       }
     }
 

--- a/server/loginHandler.js
+++ b/server/loginHandler.js
@@ -169,6 +169,17 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
       },
     };
 
+    if (LDAP.settings_get('LDAP_SYNC_ADMIN_STATUS') === true) {
+      log_debug('Updating admin status');
+      const targetGroups = LDAP.settings_get('LDAP_SYNC_ADMIN_GROUPS').split(',');
+      const groups = ldap.getUserGroups(username, ldapUser).filter((value) => targetGroups.includes(value));
+
+      if (groups.length > 0) {
+        user.isAdmin = true;
+        Meteor.users.update({_id: user.userId()}, {$set: {isAdmin: true}});
+      }
+    }
+
     if( LDAP.settings_get('LDAP_SYNC_GROUP_ROLES') === true ) {
       log_debug('Updating Groups/Roles');
       const groups = ldap.getUserGroups(username, ldapUser);
@@ -206,6 +217,17 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
   }
 
   const result = addLdapUser(ldapUser, username, loginRequest.ldapPass);
+
+  if (LDAP.settings_get('LDAP_SYNC_ADMIN_STATUS') === true) {
+    log_debug('Updating admin status');
+    const targetGroups = LDAP.settings_get('LDAP_SYNC_ADMIN_GROUPS').split(',');
+    const groups = ldap.getUserGroups(username, ldapUser).filter((value) => targetGroups.includes(value));
+
+    if (groups.length > 0) {
+      result.isAdmin = true;
+      Meteor.users.update({_id: result.userId}, {$set: {isAdmin: true}});
+    }
+  }
 
   if( LDAP.settings_get('LDAP_SYNC_GROUP_ROLES') === true ) {
     const groups = ldap.getUserGroups(username, ldapUser);

--- a/server/loginHandler.js
+++ b/server/loginHandler.js
@@ -174,10 +174,8 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
       const targetGroups = LDAP.settings_get('LDAP_SYNC_ADMIN_GROUPS').split(',');
       const groups = ldap.getUserGroups(username, ldapUser).filter((value) => targetGroups.includes(value));
 
-      if (groups.length > 0) {
-        user.isAdmin = true;
-        Meteor.users.update({_id: user.userId}, {$set: {isAdmin: true}});
-      }
+      user.isAdmin = groups.length > 0;
+      Meteor.users.update({_id: user._id}, {$set: {isAdmin: user.isAdmin}});
     }
 
     if( LDAP.settings_get('LDAP_SYNC_GROUP_ROLES') === true ) {
@@ -223,10 +221,8 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
     const targetGroups = LDAP.settings_get('LDAP_SYNC_ADMIN_GROUPS').split(',');
     const groups = ldap.getUserGroups(username, ldapUser).filter((value) => targetGroups.includes(value));
 
-    if (groups.length > 0) {
-      result.isAdmin = true;
-      Meteor.users.update({_id: result.userId}, {$set: {isAdmin: true}});
-    }
+    result.isAdmin = groups.length > 0;
+    Meteor.users.update({_id: result.userId}, {$set: {isAdmin: result.isAdmin}});
   }
 
   if( LDAP.settings_get('LDAP_SYNC_GROUP_ROLES') === true ) {


### PR DESCRIPTION
This would adds the possibility to sync the status of the isAdmin flag based on ldap group membership.

Therefor i added two new configuration options:

LDAP_SYNC_ADMIN_STATUS: boolean flag to enable admin status sync
LDAP_SYNC_ADMIN_GROUPS: comma separated list of groups. If an ldap synced user ist member of any of this groups the admin flag will be set to true.

The sync check will performed on every login.

Additionally i've added a feature wich prevents the first user who logged in to the system automatically get root, even if he's not in a privileged group.

I think this pull request solves issue #19 