### PR TITLE
Convert email address obtained from LDAP to lowercase before comparin…

### DIFF
--- a/server/loginHandler.js
+++ b/server/loginHandler.js
@@ -134,7 +134,7 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
 
   if (!user && email && LDAP.settings_get('LDAP_EMAIL_MATCH_ENABLE') === true) {
 
-    log_info('No user exists with username', username, '- attempting to find by e-mail address instead');
+    log_info(`No user exists with username ${username} - attempting to find by e-mail address instead`);
 
     if(LDAP.settings_get('LDAP_EMAIL_MATCH_VERIFIED') === true) {
       userQuery = {

--- a/server/sync.js
+++ b/server/sync.js
@@ -74,13 +74,16 @@ export function getLdapUsername(ldapUser) {
 export function getLdapEmail(ldapUser) {
   const emailField = LDAP.settings_get('LDAP_EMAIL_FIELD');
 
+  let email;
   if (emailField.indexOf('#{') > -1) {
-    return emailField.replace(/#{(.+?)}/g, function(match, field) {
+    email = emailField.replace(/#{(.+?)}/g, function (match, field) {
       return ldapUser.getLDAPValue(field);
     });
+  } else {
+    email = ldapUser.getLDAPValue(emailField);
   }
 
-  return ldapUser.getLDAPValue(emailField);
+  return email.toLowerCase();
 }
 
 export function getLdapFullname(ldapUser) {


### PR DESCRIPTION
- Convert email address obtained from LDAP to lowercase before comparing it for merging with an existing account.
- Fix a log message which discarded the second part of the message.

Resolves #81 